### PR TITLE
[light_scattered] Floating-point suffix unsupported prior to GLSL ES 3.00

### DIFF
--- a/assets/shaders/effects/light_scattered.prog
+++ b/assets/shaders/effects/light_scattered.prog
@@ -27,7 +27,7 @@
             uniform vec2 u_light_position;
 
             const int   samples = 4;
-            const float samples_r = 1.0 / 8.0f;
+            const float samples_r = 1.0 / 8.0;
 
             void main()
             {


### PR DESCRIPTION
Hello.

While [working](https://github.com/TheVice/elements/tree/SwiftShader) with libGLESv2 from [SwiftShader](https://swiftshader.googlesource.com/SwiftShader) I have met with message from the title of this pull request.
May be and in master project this change will be useful.

Have a nice day.