### PR TITLE
[models/model.prog] Floating-point suffix unsupported prior to GLSL ES 3.00

### DIFF
--- a/assets/shaders/models/model.prog
+++ b/assets/shaders/models/model.prog
@@ -30,14 +30,14 @@
 
             void main()
             {
-                gl_Position = u_matrix_mvp * vec4(a_vertex_pos, 1.0f);
+                gl_Position = u_matrix_mvp * vec4(a_vertex_pos, 1.0);
                 v_uv = a_vertex_uv;
 
                 mat3 tbn = fn_tbn_matrix();
 
                 v_light = tbn * u_light_pos;
                 v_camera = tbn * u_camera_pos;
-                v_pos = tbn * vec3(u_matrix_world * vec4(a_vertex_pos, 1.0f));
+                v_pos = tbn * vec3(u_matrix_world * vec4(a_vertex_pos, 1.0));
             }
         ]]></vertex>
 


### PR DESCRIPTION
Hello.

Error same like in [previous pull request](https://github.com/PkXwmpgN/elements/pull/7) but shader now different.
I catch that error at character demo while merging your change into SwiftShader branch. 

Thank you.
