### PR TITLE
[product.h] added template into friend declaration to prevent show warning -Wno-non-template-friend

### DIFF
--- a/elements/utils/std/product.h
+++ b/elements/utils/std/product.h
@@ -55,8 +55,14 @@ public:
 
     bool invalid() const;
 
-    friend bool operator==(const product & l, const product & r);
-    friend bool operator!=(const product & l, const product & r);
+    friend bool operator==(const product & l, const product & r)
+    {
+        return l.value_ == r.value_;
+    }
+    friend bool operator!=(const product & l, const product & r)
+    {
+        return l.value_ != r.value_;
+    }
 
 private:
 
@@ -133,20 +139,6 @@ template<typename _Type, _Type _Default>
 inline void product<_Type, _Default>::swap(product<_Type, _Default> & r)
 {
     std::swap(value_, r.value_);
-}
-
-template<typename _Type, _Type _Default>
-inline bool operator==(const product<_Type, _Default> & l,
-                       const product<_Type, _Default> & r)
-{
-    return l.value_ == r.value_;
-}
-
-template<typename _Type, _Type _Default>
-inline bool operator!=(const product<_Type, _Default> & l,
-                       const product<_Type, _Default> & r)
-{
-    return l.value_ != r.value_;
 }
 
 template<typename _Product>


### PR DESCRIPTION
Hello.

To prevent showing warning Wno-non-template-friend from product.h I propose this changes.
As reference and explanation used [this](http://www.cplusplus.com/forum/general/23865/#msg125445).

Thank you.
