### PR TITLE
[prog] set version of GLSL in shader files

### DIFF
--- a/elements/rendering/utils/program_loader.cpp
+++ b/elements/rendering/utils/program_loader.cpp
@@ -28,8 +28,18 @@ IN THE SOFTWARE.
 
 #include "assets/assets_storage.h"
 
+#include <unordered_map>
+
 namespace eps {
 namespace rendering {
+
+const std::unordered_map<std::string, std::string> versions_map =
+{
+    {"100_es", "#version 100\n"},
+    {"300_es", "#version 300 es\n"},
+    {"310_es", "#version 310 es\n"}
+};
+const char * default_version_key = "100_es";
 
 bool program_data::read(const pugi::xml_document & doc)
 {
@@ -44,8 +54,20 @@ bool program_data::read(const pugi::xml_document & doc)
     if(fragment_node.text().empty())
         return false;
 
-    v_shader_ = vertex_node.text().get();
-    f_shader_ = fragment_node.text().get();
+    v_shader_.clear();
+    f_shader_.clear();
+
+    auto shader_node = root_node.child("shaders");
+    const char * key = shader_node.attribute("version").as_string(default_version_key);
+    auto it = versions_map.find(key);
+    if(it == versions_map.end())
+        return false;
+
+    v_shader_ += it->second;
+    v_shader_ += vertex_node.text().get();
+
+    f_shader_ += it->second;
+    f_shader_ += fragment_node.text().get();
 
     pugi::xml_node a_locations_node = root_node.child("a_locations");
     for(const auto & value : a_locations_node.children("location"))

--- a/elements/rendering/utils/program_loader.h
+++ b/elements/rendering/utils/program_loader.h
@@ -56,8 +56,8 @@ public:
 
     using asset_xml::asset_xml;
 
-    const char * v_shader() const { return v_shader_; }
-    const char * f_shader() const { return f_shader_; }
+    const char * v_shader() const { return v_shader_.c_str(); }
+    const char * f_shader() const { return f_shader_.c_str(); }
 
     locations_range a_locations() const
     {
@@ -80,8 +80,8 @@ private:
     locations attribute_locations_;
     locations uniform_locations_;
 
-    const char * v_shader_ = nullptr;
-    const char * f_shader_ = nullptr;
+    std::string v_shader_;
+    std::string f_shader_;
 };
 
 bool load_program(const char * program_asset, program & result);


### PR DESCRIPTION
Hello.

According to [GLSL recommendations](https://www.opengl.org/wiki/GLSL_:_recommendations) setting version of shader language it a good practice.
From practice side it allow to run desktop samples on Ubuntu 16.04 without install vendor specific video driver as based (out of box) driver include support for version of GLSL 100 (a.k.a. GLSL ES version 1.00) that used in [OpenGL ES 2.0](https://www.khronos.org/opengles/sdk/docs/reference_cards/OpenGL-ES-2_0-Reference-card.pdf).

Thank you.