### PR TITLE
[includes] revert regressive change made for MinGW and GCC compilers.

### DIFF
--- a/elements/simulation/liquid/system.cpp
+++ b/elements/simulation/liquid/system.cpp
@@ -30,6 +30,7 @@ IN THE SOFTWARE.
 
 #include <random>
 #include <vector>
+#include <algorithm>
 
 namespace eps {
 namespace simulation {


### PR DESCRIPTION
Hello.

After we discussed that _[implicit inclusion is bad](https://github.com/PkXwmpgN/elements/pull/13#issuecomment-252127402)_ I start revert change that made by includes branch.

While this process I detect some conflict that come with [change made at next commit](https://github.com/PkXwmpgN/elements/commit/822c8622f90db50521e4bb19319c6fb9b00b6454#diff-3927577e3086d93c15c21acd5b7c841cL34). Actually that also regressive change for MinGW and GCC compilers: `elements/simulation/liquid/system.cpp:56:5: error: 'generate' is not a member of 'std'`.

So if you still [interesting](https://github.com/PkXwmpgN/elements/commit/f17ce0947a541e4c144a712a2c531171e9367047) support that compilers, personally I use MinGW 5.3.0 and out from the box on Ubuntu 16.04 - GCC 5.4.0, current change proposed.

Thank you.
