### PR TITLE
[CMakeLists.txt] pop-up to version 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.3)
 
 project("elements")
 


### PR DESCRIPTION
Hello.

In CMakeLists.txt used instruction [added](https://cmake.org/cmake/help/v3.4/release/3.3.html#generator-expressions) to CMake language starting from version 3.3.
So it is will be nice that minimum required version will be 3.3

Otherwise next can be outputted:

> C:\cmake-2.8.12.2-win32-x86\bin\cmake.exe C:\elements
> ...
> CMake Error at CMakeLists.txt:370 (target_compile_options):
>   Error evaluating generator expression:
> 
>     $<COMPILE_LANGUAGE:CXX>
> 
>   Expression did not evaluate to a known generator expression
> 

Thank you.