### PR TITLE
[build] fixed typo at target_compile_options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -554,9 +554,9 @@ if(EXPERIMENTS_SOURCE_FILES)
         target_link_libraries(experiments ${NDK_LIBRARY_ANDROID} elements atomic
             ${EXTERNAL_LIBRARIES} ${NDK_LIBRARY_GLSE2} ${NDK_LIBRARY_LOG})
         target_include_directories(experiments PRIVATE ${JNI_PATH})
-        target_compile_options(elements PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
-        target_compile_options(elements PUBLIC $<$<CONFIG:DEBUG>:-Wall -Wextra -Werror>)
-        target_compile_options(elements PUBLIC $<$<CONFIG:RELEASE>:-O3 -ffast-math -Wall -Wextra -Werror>)
+        target_compile_options(experiments PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-std=c++14>)
+        target_compile_options(experiments PUBLIC $<$<CONFIG:DEBUG>:-Wall -Wextra -Werror>)
+        target_compile_options(experiments PUBLIC $<$<CONFIG:RELEASE>:-O3 -ffast-math -Wall -Wextra -Werror>)
 
     endif()
 endif()


### PR DESCRIPTION
Hello.

It seems that there is mistake when set target_compile_options for elements second time on line [557-559](https://github.com/PkXwmpgN/elements/blob/171aa3b6ddeef4cbd005821bb2cd6eaaf2a774eb/CMakeLists.txt#L557). First time was at [370-372](https://github.com/PkXwmpgN/elements/blob/171aa3b6ddeef4cbd005821bb2cd6eaaf2a774eb/CMakeLists.txt#L370).
The reason why no compile error it because elements is dependence of experiments - CMake apply compile options of dependence to target that use it.

Thank you.